### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gh-container-registry.yml
+++ b/.github/workflows/gh-container-registry.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build and push container image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ghcr.io/kondoumh/gh-container-registry/nodejs-server
         username: kondoumh


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore